### PR TITLE
Don't coalesce the blocked product and raked product by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ julia> print_layout(logical_product(tile, matrix_of_tiles));
 #### Blocked product
 
 ```julia
-julia> print_layout(blocked_product(tile, matrix_of_tiles))
-((2, 3), 8):((1, 16), 2)
+julia>  print_layout(blocked_product(tile, matrix_of_tiles))
+((2, 3), (2, 4)):((1, 16), (2, 4))
        1    2    3    4    5    6    7    8
     +----+----+----+----+----+----+----+----+
  1  |  1 |  3 |  5 |  7 |  9 | 11 | 13 | 15 |

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -408,8 +408,7 @@ function blocked_product(block::Layout{N}, layout::Layout{M}, coalesce_result = 
     padded_layout = append(layout, R)
     result = logical_product(padded_block, padded_layout)
     result = _transpose(result[1], result[2])
-    if coalesce_result
-        return coalesce(result, repeat(static(1), R))
+    coalesce_result && return coalesce(result, repeat(static(1), R))
     return result
 end
 
@@ -419,8 +418,7 @@ function raked_product(block::Layout{N}, layout::Layout{M}, coalesce_result = fa
     padded_layout = append(layout, R)
     result = logical_product(padded_block, padded_layout)
     result = _transpose(result[2], result[1])
-    if coalesce_result
-        return coalesce(result, repeat(static(1), R))
+    coalesce_result && return coalesce(result, repeat(static(1), R))
     return result
 end
 

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -407,7 +407,7 @@ function blocked_product(block::Layout{N}, layout::Layout{M}) where {N, M}
     padded_block = append(block, R)
     padded_layout = append(layout, R)
     result = logical_product(padded_block, padded_layout)
-    return coalesce(_transpose(result[1], result[2]), repeat(1, R))
+    return _transpose(result[1], result[2])
 end
 
 function raked_product(block::Layout{N}, layout::Layout{M}) where {N, M}
@@ -415,7 +415,7 @@ function raked_product(block::Layout{N}, layout::Layout{M}) where {N, M}
     padded_block = append(block, R)
     padded_layout = append(layout, R)
     result = logical_product(padded_block, padded_layout)
-    return coalesce(_transpose(result[2], result[1]), repeat(static(1), R))
+    return _transpose(result[2], result[1])
 end
 
 # tile_to_shape

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -402,20 +402,26 @@ function tiled_product(layout::Layout, tile::Tile{N}) where {N}
     return d(:, repeat(:, N))
 end
 
-function blocked_product(block::Layout{N}, layout::Layout{M}) where {N, M}
+function blocked_product(block::Layout{N}, layout::Layout{M}, coalesce_result = false) where {N, M}
     R = max(N, M)
     padded_block = append(block, R)
     padded_layout = append(layout, R)
     result = logical_product(padded_block, padded_layout)
-    return _transpose(result[1], result[2])
+    result = _transpose(result[1], result[2])
+    if coalesce_result
+        return coalesce(result, repeat(static(1), R))
+    return result
 end
 
-function raked_product(block::Layout{N}, layout::Layout{M}) where {N, M}
+function raked_product(block::Layout{N}, layout::Layout{M}, coalesce_result = false) where {N, M}
     R = max(N, M)
     padded_block = append(block, R)
     padded_layout = append(layout, R)
     result = logical_product(padded_block, padded_layout)
-    return _transpose(result[2], result[1])
+    result = _transpose(result[2], result[1])
+    if coalesce_result
+        return coalesce(result, repeat(static(1), R))
+    return result
 end
 
 # tile_to_shape

--- a/test/layout.jl
+++ b/test/layout.jl
@@ -27,7 +27,7 @@ end
         @test stride(result) == ((1, 2), (16, 4))
     end
     @testset "Blocked product" begin
-        result = blocked_product(tile, matrix_of_tiles)
+        result = coalesce(blocked_product(tile, matrix_of_tiles), repeat(1, 2))
         @test shape(result) == ((2, 3), 8)
         @test stride(result) == ((1, 16), 2)
     end

--- a/test/layout.jl
+++ b/test/layout.jl
@@ -27,12 +27,12 @@ end
         @test stride(result) == ((1, 2), (16, 4))
     end
     @testset "Blocked product" begin
-        result = coalesce(blocked_product(tile, matrix_of_tiles), repeat(1, 2))
+        result = blocked_product(tile, matrix_of_tiles, true)
         @test shape(result) == ((2, 3), 8)
         @test stride(result) == ((1, 16), 2)
     end
     @testset "Raked product" begin
-        result = raked_product(tile, matrix_of_tiles)
+        result = raked_product(tile, matrix_of_tiles, true)
         @test shape(result) == ((3, 2), (4, 2))
         @test stride(result) == ((16, 1), (4, 2))
     end


### PR DESCRIPTION
This allows us to make better use of the h-D indices of the product. There's an bonus: constructing things like BlockArrays becomes effortless.